### PR TITLE
tab -> space

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Brief introduction：
 (1) Clone the project
 
 ```
-$ git clone　https://github.com/imfly/electron-docs-gitbook.git
+$ git clone https://github.com/imfly/electron-docs-gitbook.git
 ```
 
 (2) Install dependences


### PR DESCRIPTION
Fix:
The "git clone" part of README.md now works with copy-and-paste. Before it failed because it contains a strange space right after clone and not a single space.


